### PR TITLE
getenv can return nullptr

### DIFF
--- a/src/emcc.cpp
+++ b/src/emcc.cpp
@@ -162,7 +162,7 @@ static std::string find_em_config_filename(const Args& args)
   const char* em_config = read_param_from_cmdline(args, "--em-config");
   if (em_config) return em_config;
   em_config = getenv("EM_CONFIG");
-  if (em_config) return em_config);
+  if (em_config) return em_config;
   return "";
 }
 

--- a/src/emcc.cpp
+++ b/src/emcc.cpp
@@ -161,7 +161,9 @@ static std::string find_em_config_filename(const Args& args)
 {
   const char* em_config = read_param_from_cmdline(args, "--em-config");
   if (em_config) return em_config;
-  return getenv("EM_CONFIG");
+  em_config = getenv("EM_CONFIG");
+  if (em_config) return em_config);
+  return "";
 }
 
 static bool find_emcc_strict_value(const Args& args)


### PR DESCRIPTION
This was resulting in

```
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_M_construct null not valid
```

if EM_CONFIG wasn't set, which was quite confusing. I'm still not sure why EM_CONFIG can't be automatically determined (emcc seems to have no trouble with it) but haven't got to figuring that out yet.